### PR TITLE
make sure car is amd64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "6379:6379"
 
   on_car:
+    platform: linux/amd64
     build: ./car
     image: "ghcr.io/forallsecure-customersolutions/mayhem-demo/car:${SHA:-latest}"
     depends_on:


### PR DESCRIPTION
This PR makes sure those working on non-x64 architectures still build the car demo for x64 so that everything is consistent.