### PR TITLE
[MH-18061] Missing TLS checks in updated demo

### DIFF
--- a/api/run-it.sh
+++ b/api/run-it.sh
@@ -5,8 +5,8 @@ PID=
 mkdir -p /app/certs
 
 # Generate an expired certificate
-openssl req -newkey rsa:4096 -nodes -keyout /app/certs/key.pem -out /app/certs/csr.pem -subj "/CN=localhost"
-openssl x509 -req -in /app/certs/csr.pem -signkey /app/certs/key.pem -out /app/certs/cert.pem -days -1
+openssl req -newkey rsa:4096 -nodes -keyout /app/certs/key.pem -out /app/certs/csr.pem -subj "/CN=localhost" -config /etc/ssl/openssl.cnf -extensions v3_req
+openssl x509 -req -in /app/certs/csr.pem -signkey /app/certs/key.pem -out /app/certs/cert.pem -days -1 -extfile /etc/ssl/openssl.cnf -extensions v3_req
 
 run_coverage_report() {
     echo "Generating coverage xml report..."


### PR DESCRIPTION
Running into https://github.com/rustls/rustls/issues/1298, our tls lib only supports v3 certificates https://github.com/rustls/webpki/blob/6a388acd5e2282e9f36e4532caac8ba5c79325ba/src/cert.rs#L123-L139 . Working out how to address this with the team, for now slightly tweak the cert generation to make this compatible.

Note that
1. unfortunately we will only report one of expired OR self signed certificate, here we'll report an issue that this is expired.
2. There are a couple other tweaks we'll need to do to mapi to get this fully working, but this workaround probably should come in